### PR TITLE
Use a specific version of Envoy

### DIFF
--- a/Dockerfile-envoy
+++ b/Dockerfile-envoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-dev:latest
+FROM envoyproxy/envoy:v1.17.0
 
 COPY service-envoy.yaml /etc/envoy/service-envoy.yaml
 CMD /usr/local/bin/envoy -c /etc/envoy/service-envoy.yaml


### PR DESCRIPTION
This is to prevent future Envoy startup errors caused by using deprecated APIs in the Envoy config.